### PR TITLE
Unique component ID

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\View\View;
 use Livewire\Component;
 use ReflectionClass;
+use Illuminate\Support\Str;
 
 class Modal extends Component
 {
@@ -29,7 +30,7 @@ class Modal extends Component
             throw new Exception("[{$componentClass}] does not implement [{$requiredInterface}] interface.");
         }
 
-        $id = md5($component . serialize($componentAttributes));
+        $id = md5($component . serialize($componentAttributes) . Str::uuid());
         $this->components[$id] = [
             'name'            => $component,
             'attributes'      => $componentAttributes,

--- a/tests/LivewireModalTest.php
+++ b/tests/LivewireModalTest.php
@@ -38,6 +38,28 @@ class LivewireModalTest extends TestCase
             ->assertEmitted('activeModalComponentChanged');
     }
 
+    public function testOpenModalUniqueComponentId() : void
+    {
+        // Demo modal component
+        Livewire::component('demo-modal', DemoModal::class);
+
+        // Event attributes
+        $component = 'demo-modal';
+        $componentAttributes = ['message' => 'Foobar'];
+        $modalAttributes = ['hello' => 'world', 'closeOnEscape' => true, 'maxWidth' => '2xl', 'closeOnClickAway' => true, 'closeOnEscapeIsForceful' => true, 'dispatchCloseEvent' => false];
+
+        $firstComponentId = Livewire::test(Modal::class)
+            ->emit('openModal', $component, $componentAttributes, $modalAttributes)
+            ->get('activeComponent');
+
+        $secondComponentId = Livewire::test(Modal::class)
+            ->emit('openModal', $component, $componentAttributes, $modalAttributes)
+            ->get('activeComponent');
+
+        // Verify components with same attributes have different component ids
+        $this->assertNotEquals($firstComponentId, $secondComponentId);
+    }
+
     public function testModalReset(): void
     {
         Livewire::component('demo-modal', DemoModal::class);

--- a/tests/LivewireModalTest.php
+++ b/tests/LivewireModalTest.php
@@ -19,23 +19,23 @@ class LivewireModalTest extends TestCase
         $componentAttributes = ['message' => 'Foobar'];
         $modalAttributes = ['hello' => 'world', 'closeOnEscape' => true, 'maxWidth' => '2xl', 'closeOnClickAway' => true, 'closeOnEscapeIsForceful' => true, 'dispatchCloseEvent' => false];
 
-        // Demo modal unique identifier
-        $id = md5($component . serialize($componentAttributes));
-
         Livewire::test(Modal::class)
+            // Verify no active component is set
+            ->assertSet('activeComponent', null)
+            // Emit open modal event
             ->emit('openModal', $component, $componentAttributes, $modalAttributes)
             // Verify component is added to $components
-            ->assertSet('components', [
-                $id => [
+            ->assertSet('components', function ($value) use ($component, $componentAttributes, $modalAttributes) {
+                return is_array($value) && count($value) == 1 && array_shift($value) == [
                     'name'            => $component,
                     'attributes'      => $componentAttributes,
                     'modalAttributes' => $modalAttributes,
-                ],
-            ])
+                ];
+            })
             // Verify component is set to active
-            ->assertSet('activeComponent', $id)
+            ->assertNotSet('activeComponent', null)
             // Verify event is emitted to client
-            ->assertEmitted('activeModalComponentChanged', $id);
+            ->assertEmitted('activeModalComponentChanged');
     }
 
     public function testModalReset(): void


### PR DESCRIPTION
I noticed an issue when opening a modal from within a modal with the same attributes. Since the component ID is a md5 hash of the component name and the serialized attributes the ID will be always the same when those to parameters are the same.

In some cases this can cause some weird behavior. Let's assume the following:

- We have a modal component called `TestModal` it shows a select input with the values 1, 2, and 3.
- In the mount method we accept the parameter `$selection` for a default selection of an option.
- Right beneath the select input there is a button which opens the same model component with the same default selection.

```php
class TestModal ...
{
    public int $selection = 0;

    public function mount(int $selection)
    {
        $this->selection = $selection;
    }
}

```
and the view:
```html
<x-modal>
    <select wire:model="selection">
        <option value="1">1</option>
        <option value="2">2</option>
        <option value="3">3</option>
    </select>

    <button wire:click="$emit('openModal', 'test-modal', { selection: 1 })">Open</button>
    <button wire:click="$emit('closeModal')">Close</button>
</x-modal>
```

### Whats the issue?
When we open the modal we see a select with a pre-selected value of "1" and an open and close button. When we select the value "3" of our select and then hit "Open" we expect (or at least I do) that a new modal opens with the pre-selected value of "1". But since the component ID of the modal to open is the same as the ID of the modal which is currently open, we don't really add a new modal. We simple overwrite the current component data and trigger the `activeComponentChanged` event which then basically runs a fade-in-fade-out animation.

The second modal (the one opened from within the first one) won't have "1" as the pre-selected value but "3" because it was selected before in the first modal.

### Solution
This PR just appends a UUID to the string that will be hashed as the component id. This way we can be sure that every new modal has a unique component id and acts as its own instance (even when the component attributes are the same).

I updated the `testOpenModalEventListener`-Test because now we can not know what the component id will be before the Modal-Component actually generated one. The test now checks if the `activeComponent` was null before emitting the `openModal` event and is not null after.

I also added another test that simply checks if the component ids are unique for the same kind of modal with the same component attributes.

### Possible Workarounds
One could add a component attribute when emitting the `openModal` event with a unique id for instance:
```php
$this->emit('openModal', 'test-modal', [
    'selection' => 1,
    'someUniqueField' => Str::uuid()
]);
```
This would result in a different string when serializing the attributes and therefore result in a different component id.