### PR TITLE
Fix order of actions on closeModalWithEvents

### DIFF
--- a/src/ModalComponent.php
+++ b/src/ModalComponent.php
@@ -63,8 +63,8 @@ abstract class ModalComponent extends Component implements Contract
 
     public function closeModalWithEvents(array $events): void
     {
-        $this->closeModal();
         $this->emitModalEvents($events);
+        $this->closeModal();
     }
 
     public static function modalMaxWidth(): string


### PR DESCRIPTION
Because of the order of actions in the closeModalWithEvents method, other components were unable to hear the emitted events. Changing this order fixes this.