### PR TITLE
Add optional chaining to modal.js

### DIFF
--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -88,7 +88,7 @@ window.LivewireUIModal = () => {
             }
 
             this.$nextTick(() => {
-                let focusable = this.$refs[id].querySelector('[autofocus]');
+                let focusable = this.$refs[id]?.querySelector('[autofocus]');
                 if (focusable) {
                     setTimeout(() => {
                         focusable.focus();


### PR DESCRIPTION
I got and ugly js error when there is no autofocus attributes on the input.