### PR TITLE
Fixed the overflow-hidden on the modal

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -17,7 +17,7 @@
             class="fixed inset-0 z-10 overflow-y-auto"
             style="display: none;"
     >
-        <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-10 text-center sm:block sm:p-0">
+        <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-10 text-center sm:block sm:p-0">
             <div
                     x-show="show"
                     x-on:click="closeModalOnClickAway()"
@@ -43,7 +43,7 @@
                     x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                     x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-bind:class="modalWidth"
-                    class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
+                    class="inline-block w-full align-bottom bg-white rounded-lg text-left shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
             >
                 @forelse($components as $id => $component)
                     <div x-show.immediate="activeComponent == '{{ $id }}'" x-ref="{{ $id }}" wire:key="{{ $id }}">


### PR DESCRIPTION
This PR fixed the modal overflow. In my case, i got a select component in the modal that doesnt show all the content.


Before
![Before!](https://i.ibb.co/6N8k1Xq/old.png)

After
![After!](https://i.ibb.co/23BZ08v/new.png)
