### PR TITLE
feature: add id to modal container

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -44,6 +44,7 @@
                     x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-bind:class="modalWidth"
                     class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
+                    id="modal-container"
             >
                 @forelse($components as $id => $component)
                     <div x-show.immediate="activeComponent == '{{ $id }}'" x-ref="{{ $id }}" wire:key="{{ $id }}">


### PR DESCRIPTION
This PR adds a `modal-container` ID to the nearest parent element to where the modals are actually rendered / injected.

Having this ID will allow developers to inject modals directly from JavaScript with `x-teleport` and other tools.

I had a scenario where I'm using this package with a Livewire component in one place and don't require a LW component in another since it's overkill for displaying static data. I'm currently using a vendor-published view with this same code change and it works great.