### PR TITLE
feature: add open-modal event to show modal container

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -10,6 +10,7 @@
             x-data="LivewireUIModal()"
             x-init="init()"
             x-on:close.stop="setShowPropertyTo(false)"
+            x-on:open-modal.window.stop="show = true"
             x-on:keydown.escape.window="closeModalOnEscape()"
             x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
             x-on:keydown.shift.tab.prevent="prevFocusable().focus()"


### PR DESCRIPTION
This one is related to #198 but figured they should be separate PRs. 

This one adds an `open-modal` event listener to the Alpine component that will allow developers to open the modal manually using `$dispatch('open-modal')` or something similar.