### PR TITLE
feature: add x-trap to modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the Livewire directive `@livewire('livewire-ui-modal')` directive to your te
 ```
 
 ## Alpine
-Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine). You can use the official CDN to quickly include Alpine:
+Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine) and the [Alpine Focus plugin](https://alpinejs.dev/plugins/focus). You can use the official CDN to quickly include Alpine:
 
 ```html
 <!-- Alpine v2 -->
@@ -42,6 +42,9 @@ Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine). Y
 
 <!-- Alpine v3 -->
 <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+
+<!-- Alpine Focus Plugin -->
+<script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
 ```
 
 ## TailwindCSS

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -36,6 +36,7 @@
 
             <div
                     x-show="show && showActiveComponent"
+                    x-trap.noscroll.inert="show && showActiveComponent"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"


### PR DESCRIPTION
This PR add x-trap to the modal so items are automatically focused upon the modal being opened. This helps with accessibility and overall UX.

This will require that people use the focus plugin in their projects.

I have created a draft PR as I am not sure if the focus plugin works with Alpine V2 and I am also having an issue where the focus will skip the first element when it wraps around, it also skips the last element if I reverse tab. 