### PR TITLE
fixes loading speed issue by moving config reads away from View composer ...

### DIFF
--- a/src/LivewireModalServiceProvider.php
+++ b/src/LivewireModalServiceProvider.php
@@ -20,15 +20,5 @@ class LivewireModalServiceProvider extends PackageServiceProvider
     public function bootingPackage(): void
     {
         Livewire::component('livewire-ui-modal', Modal::class);
-
-        View::composer('livewire-ui-modal::modal', function ($view) {
-            if (config('livewire-ui-modal.include_js', true)) {
-                $view->jsPath = __DIR__.'/../public/modal.js';
-            }
-
-            if (config('livewire-ui-modal.include_css', false)) {
-                $view->cssPath = __DIR__ . '/../public/modal.css';
-            }
-        });
     }
 }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -64,6 +64,17 @@ class Modal extends Component
 
     public function render(): View
     {
-        return view('livewire-ui-modal::modal');
+        if (config('livewire-ui-modal.include_js', true)) {
+            $jsPath = __DIR__.'/../public/modal.js';
+        }
+
+        if (config('livewire-ui-modal.include_css', false)) {
+            $cssPath = __DIR__ . '/../public/modal.css';
+        }
+
+        return view('livewire-ui-modal::modal', [
+            'jsPath' => $jsPath ?? null,
+            'cssPath' => $cssPath ?? null,
+        ]);
     }
 }


### PR DESCRIPTION
… and into the Livewire component

Fixes #238 

As reported in the above issue, there is a speed issue when using `View::composer`.

I haven't found the root cause of it and why this call is so slow, but by moving the configuration checks away from `View::composer` and into the `Modal` livewire component, the problem is resolved.