### PR TITLE
Allows elements to go outside the container (datepickers, dropdowns, tooltips)

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -43,7 +43,7 @@
                     x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                     x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-bind:class="modalWidth"
-                    class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
+                    class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
                     id="modal-container"
             >
                 @forelse($components as $id => $component)


### PR DESCRIPTION
Mobile behaviour depends on the content inside the modal and is out of scope for this issue as that can be handled by the content itself (position wise).

<img width="453" alt="Screenshot 2022-10-06 at 14 43 14" src="https://user-images.githubusercontent.com/866743/194315677-a6ff2974-8da6-419d-9483-591967c65884.png">
