### PR TITLE
Removing unused imports and trailing spaces

### DIFF
--- a/config/livewire-ui-modal.php
+++ b/config/livewire-ui-modal.php
@@ -40,7 +40,7 @@ return [
     */
     'component_defaults' => [
         'modal_max_width' => '2xl',
-        
+
         'close_modal_on_click_away' => true,
 
         'close_modal_on_escape' => true,
@@ -48,7 +48,7 @@ return [
         'close_modal_on_escape_is_forceful' => true,
 
         'dispatch_close_event' => false,
-        
+
         'destroy_on_close' => false,
     ],
 ];

--- a/src/LivewireModalServiceProvider.php
+++ b/src/LivewireModalServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace LivewireUI\Modal;
 
-use Illuminate\Support\Facades\View;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;

--- a/src/ModalComponent.php
+++ b/src/ModalComponent.php
@@ -83,7 +83,7 @@ abstract class ModalComponent extends Component implements Contract
 
         return static::$maxWidths[static::modalMaxWidth()];
     }
-    
+
     public static function closeModalOnClickAway(): bool
     {
         return config('livewire-ui-modal.component_defaults.close_modal_on_click_away', true);

--- a/tests/LivewireModalTest.php
+++ b/tests/LivewireModalTest.php
@@ -7,15 +7,13 @@ use LivewireUI\Modal\Modal;
 use LivewireUI\Modal\Tests\Components\DemoModal;
 use LivewireUI\Modal\Tests\Components\InvalidModal;
 
-use function PHPUnit\Framework\assertArrayNotHasKey;
-
 class LivewireModalTest extends TestCase
 {
     public function testOpenModalEventListener(): void
     {
         // Demo modal component
         Livewire::component('demo-modal', DemoModal::class);
-        
+
         // Event attributes
         $component = 'demo-modal';
         $componentAttributes = [ 'message' => 'Foobar' ];
@@ -23,7 +21,7 @@ class LivewireModalTest extends TestCase
         
         // Demo modal unique identifier
         $id = md5($component . serialize($componentAttributes));
-        
+
         Livewire::test(Modal::class)
             ->emit('openModal', $component, $componentAttributes, $modalAttributes)
             // Verify component is added to $components
@@ -39,19 +37,19 @@ class LivewireModalTest extends TestCase
             // Verify event is emitted to client
             ->assertEmitted('activeModalComponentChanged', $id);
     }
-    
+
     public function testDestroyComponentEventListener(): void
     {
         // Demo modal component
         Livewire::component('demo-modal', DemoModal::class);
-        
+
         $component = 'demo-modal';
         $componentAttributes = [ 'message' => 'Foobar' ];
         $modalAttributes = [ 'hello' => 'world', 'closeOnEscape' => true, 'maxWidth' => '2xl', 'maxWidthClass' => 'sm:max-w-md md:max-w-xl lg:max-w-2xl', 'closeOnClickAway' => true, 'closeOnEscapeIsForceful' => true, 'dispatchCloseEvent' => false, 'destroyOnClose' => false ];
         
         // Demo modal unique identifier
         $id = md5($component . serialize($componentAttributes));
-        
+
         Livewire::test(Modal::class)
             ->emit('openModal', $component, $componentAttributes, $modalAttributes)
             ->assertSet('components', [
@@ -63,13 +61,12 @@ class LivewireModalTest extends TestCase
             ])
             ->emit('destroyComponent', $id)
             ->assertSet('components', []);
-        
     }
-    
+
     public function testModalReset(): void
     {
         Livewire::component('demo-modal', DemoModal::class);
-        
+
         Livewire::test(Modal::class)
             ->emit('openModal', 'demo-modal')
             ->set('components', [
@@ -85,13 +82,13 @@ class LivewireModalTest extends TestCase
             ->assertSet('activeComponent', null)
             ->assertSet('components', []);
     }
-    
+
     public function testIfExceptionIsThrownIfModalDoesNotImplementContract(): void
     {
         $component = InvalidModal::class;
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("[{$component}] does not implement [LivewireUI\Modal\Contracts\ModalComponent] interface.");
-        
+
         Livewire::component('invalid-modal', $component);
         Livewire::test(Modal::class)->emit('openModal', 'invalid-modal');
     }


### PR DESCRIPTION
Hey @PhiloNL 

just a bit tidy up: Removing some unused "use"-statements and trailing spaces.

Cheers,
Peter