### PR TITLE
updates modal.php to use route model resolver to inject models

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,23 +85,23 @@ To open a modal you will need to emit an event. To open the `EditUser` modal for
 ```
 
 ## Passing parameters
-To open the `EditUser` modal for a specific user we can pass the user id (notice the single quotes):
+To open the `EditUser` modal for a specific user we can pass the user id:
 
 ```html
 <!-- Outside of any Livewire component -->
-<button onclick='Livewire.emit("openModal", "edit-user", {{ json_encode(["user" => $user->id]) }})'>Edit User</button>
+<button onclick="Livewire.emit('openModal', 'edit-user', {{ json_encode(['user' => $user->id]) }})">Edit User</button>
 
 <!-- Inside existing Livewire component -->
-<button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->id]) }})'>Edit User</button>
+<button wire:click="$emit('openModal', 'edit-user', {{ json_encode(['user' => $user->id]) }})">Edit User</button>
 
 <!-- If you use a different primaryKey (e.g. email), adjust accordingly -->
-<button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->email]) }})'>Edit User</button>
+<button wire:click="$emit('openModal', 'edit-user', {{ json_encode(['user' => $user->email]) }})">Edit User</button>
 
 <!-- Example of passing multiple parameters -->
-<button wire:click='$emit("openModal", "edit-user", {{ json_encode([$user->id, $isAdmin]) }})'>Edit User</button>
+<button wire:click="$emit('openModal', 'edit-user', {{ json_encode([$user->id, $isAdmin]) }})">Edit User</button>
 ```
 
-The parameters are passed to the `mount` method on the modal component:
+The parameters are injected into the modal component and the model will be automatically fetched from the database if the type is defined:
 
 ```php
 <?php
@@ -113,13 +113,14 @@ use LivewireUI\Modal\ModalComponent;
 
 class EditUser extends ModalComponent
 {
+    // This will inject just the ID
+    // public int $user;
+
     public User $user;
 
-    public function mount(User $user)
+    public function mount()
     {
-        Gate::authorize('update', $user);
-
-        $this->user = $user;
+        Gate::authorize('update', $this->user);
     }
 
     public function render()
@@ -128,6 +129,8 @@ class EditUser extends ModalComponent
     }
 }
 ```
+
+The parameters are also passed to the `mount` method on the modal component.
 
 ## Opening a child modal
 From an existing modal you can use the exact same event and a child modal will be created:
@@ -160,16 +163,14 @@ class EditUser extends ModalComponent
 {
     public User $user;
 
-    public function mount(User $user)
+    public function mount()
     {
-        Gate::authorize('update', $user);
-
-        $this->user = $user;
+        Gate::authorize('update', $this->user);
     }
 
     public function update()
     {
-        Gate::authorize('update', $user);
+        Gate::authorize('update', $this->user);
 
         $this->user->update($data);
 
@@ -188,7 +189,7 @@ If you don't want to go to the previous modal but close the entire modal compone
 ```php
 public function update()
 {
-    Gate::authorize('update', $user);
+    Gate::authorize('update', $this->user);
 
     $this->user->update($data);
 
@@ -201,7 +202,7 @@ Often you will want to update other Livewire components when changes have been m
 ```php
 public function update()
 {
-    Gate::authorize('update', $user);
+    Gate::authorize('update', $this->user);
 
     $this->user->update($data);
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,4 +9,8 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -3,6 +3,10 @@
 namespace LivewireUI\Modal;
 
 use Exception;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Reflector;
 use Illuminate\View\View;
 use Livewire\Component;
 use ReflectionClass;
@@ -30,9 +34,14 @@ class Modal extends Component
         }
 
         $id = md5($component . serialize($componentAttributes));
+
+        $componentAttributes = collect($componentAttributes)
+            ->merge($this->resolveComponentProps($componentAttributes, new $componentClass()))
+            ->all();
+
         $this->components[$id] = [
-            'name'            => $component,
-            'attributes'      => $componentAttributes,
+            'name' => $component,
+            'attributes' => $componentAttributes,
             'modalAttributes' => array_merge([
                 'closeOnClickAway' => $componentClass::closeModalOnClickAway(),
                 'closeOnEscape' => $componentClass::closeModalOnEscape(),
@@ -47,6 +56,51 @@ class Modal extends Component
         $this->activeComponent = $id;
 
         $this->emit('activeModalComponentChanged', $id);
+    }
+
+    public function resolveComponentProps(array $attributes, Component $component)
+    {
+        if (PHP_VERSION_ID < 70400) {
+            return;
+        }
+
+        return $this->getPublicPropertyTypes($component)
+            ->intersectByKeys($attributes)
+            ->map(function ($className, $propName) use ($attributes) {
+                $resolved = $this->resolveParameter($attributes, $propName, $className);
+
+                return $resolved;
+            });
+    }
+
+    protected function resolveParameter($attributes, $parameterName, $parameterClassName)
+    {
+        $parameterValue = $attributes[$parameterName];
+
+        if ($parameterValue instanceof UrlRoutable) {
+            return $parameterValue;
+        }
+
+        $instance = app()->make($parameterClassName);
+
+        if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+            throw (new ModelNotFoundException())->setModel(get_class($instance), [$parameterValue]);
+        }
+
+        return $model;
+    }
+
+    public function getPublicPropertyTypes($component)
+    {
+        if (PHP_VERSION_ID < 70400) {
+            return new Collection();
+        }
+
+        return collect($component->getPublicPropertiesDefinedBySubClass())
+            ->map(function ($value, $name) use ($component) {
+                return Reflector::getParameterClassName(new \ReflectionProperty($component, $name));
+            })
+            ->filter();
     }
 
     public function destroyComponent($id): void

--- a/tests/Components/DemoModal.php
+++ b/tests/Components/DemoModal.php
@@ -3,14 +3,25 @@
 namespace LivewireUI\Modal\Tests\Components;
 
 use LivewireUI\Modal\ModalComponent;
+use LivewireUI\Modal\Tests\Models\TestUser;
 
 class DemoModal extends ModalComponent
 {
+    public TestUser $user;
+    public $number;
+    public $message;
+
+    public function mount(TestUser $user)
+    {
+        $this->user = $user;
+    }
+
     public function render()
     {
-        return <<<'blade'
+        return <<<blade
             <div>
-                Hello
+                {$this->user->first_name} says:
+                {$this->message} + {$this->number}
             </div>
         blade;
     }

--- a/tests/Models/TestUser.php
+++ b/tests/Models/TestUser.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LivewireUI\Modal\Tests\Models;
+
+class TestUser extends \Illuminate\Database\Eloquent\Model {
+	
+}


### PR DESCRIPTION
Updates the `Modal.php` to use an adapted version of the Livewire route model resolver.

Models are directly injected into the modal component. Basically the same way as if you use a full page component (via route) in Livewire.

I use it all the time in my projects but I override `Modal.php` via `AliasLoader::class`.

Would solve issues stated in these 2 issues:
https://github.com/wire-elements/modal/issues/197
https://github.com/wire-elements/modal/issues/60