### PR TITLE
Fix ordering of CDN imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the Livewire directive `@livewire('livewire-ui-modal')` directive to your te
 ```
 
 ## Alpine
-Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine) and the plugin[Focus](https://alpinejs.dev/plugins/focus). You can use the official CDN to quickly include Alpine:
+Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine) and the plugin [Focus](https://alpinejs.dev/plugins/focus). You can use the official CDN to quickly include Alpine:
 
 ```html
 <!-- Focus plugin -->

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ Add the Livewire directive `@livewire('livewire-ui-modal')` directive to your te
 Livewire Elements Modal requires [Alpine](https://github.com/alpinejs/alpine) and the plugin[Focus](https://alpinejs.dev/plugins/focus). You can use the official CDN to quickly include Alpine:
 
 ```html
+<!-- Focus plugin -->
+<script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+
 <!-- Alpine v3 -->
 <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
-<!-- Focus plugin -->
-<script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
 ```
 
 ## TailwindCSS


### PR DESCRIPTION
The focus plugin is required to be loaded before the core Alpine scripts as per official docs [Installation Via CDN](https://alpinejs.dev/plugins/focus#installation)