### PR TITLE
[fix] allow enum binding

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -84,6 +84,14 @@ class Modal extends Component
             return $parameterValue;
         }
 
+        if(enum_exists($parameterClassName)){
+            $enum = $parameterClassName::tryFrom($parameterValue);
+        
+            if($enum !== null){
+                return $enum;
+            }
+        }
+
         $instance = app()->make($parameterClassName);
 
         if (! $model = $instance->resolveRouteBinding($parameterValue)) {


### PR DESCRIPTION
Hi, 

this PR will enable enum binding in modal parameters, this will allow to call

```html
<button type="button" wire:click="$dispatch('openModal', {'component':'invoices.select-invoice','arguments':{'type':'outbound','status':'pending',}})">
    select invoice
</button>
```

with a modal like this one:

```php
class SelectInvoice extends ModalComponent
{
    #[Rule('required')]
    public \App\Enums\Type $type;

    #[Rule('nullable')]
    public \App\Enums\Status $status;

    //...
}
```

before this fix, you will encounter this exception: `Target [App\Enums\Type] is not instantiable.`

with 6 lines of code, the enum value is resolved to its calss