### PR TITLE
fix missing ")" on query selector

### DIFF
--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -101,7 +101,7 @@ window.LivewireUIModal = () => {
             });
         },
         focusables() {
-            let selector = 'a, button, input:not([type=\'hidden\'], textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+            let selector = 'a, button, input:not([type=\'hidden\'], textarea, select, details, [tabindex]:not([tabindex=\'-1\']))'
 
             return [...this.$el.querySelectorAll(selector)]
                 .filter(el => !el.hasAttribute('disabled'))


### PR DESCRIPTION
### Description
This PR updates the JavaScript query selector used in `modal.focusables()`. The update corrects the syntax of the `:not pseudo-class` applied to input elements, ensuring hidden inputs are properly excluded from the selection. This change enhances the functionality and reliability of our UI element selection logic.

### Changes
- Corrected the placement of parentheses in the query selector string.

Thanks for your time!