### PR TITLE
Replaces `min-h-screen` with `min-h-dvh`

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -14,7 +14,7 @@
             class="fixed inset-0 z-10 overflow-y-auto"
             style="display: none;"
     >
-        <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-10 text-center sm:block sm:p-0">
+        <div class="flex items-end justify-center min-h-dvh px-4 pt-4 pb-10 text-center sm:block sm:p-0">
             <div
                     x-show="show"
                     x-on:click="closeModalOnClickAway()"


### PR DESCRIPTION
Utilizing DVH (Dynamic Viewport Height) will result in consistent results for showing the modal in mobile phones.

Currently, the modal on mobile screens is getting cut at the bottom when the address bar is showing but this PR will make sure the modal is inside the viewport.

Actually, this PR resolves #91 