### PR TITLE
Dispatch an event to a modal being closed before closing it, so that the modal can prevent it based on its state

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,29 @@ By default, the modal will close when you click outside the modal. If you want t
  }
  ```
 
+## Preventing closing the modal on Escape or on click away based on the modal state
+
+When a modal is closed on Escape or click away, `closingModalOnEscape` and `closingModalOnClickAway` are issued. Handle these events to prevent closing a modal based on its state, for example, if there are uncommitted changes.
+
+For example, if a modal has a `isDirty` property, it could have the following handler:
+
+```
+@script
+<script>
+    $wire.on('closingModalOnEscape', data => {
+        if ($wire.isDirty && !confirm('{{ __('You have unsaved changes. Are you sure you want to close this dialog?') }}')) {
+            data.closing = false;
+        }
+    });
+    $wire.on('closingModalOnClickAway', data => {
+        if ($wire.isDirty && !confirm('{{ __('You have unsaved changes. Are you sure you want to close this dialog?') }}')) {
+            data.closing = false;
+        }
+    });
+</script>
+@endscript
+```
+
 ## Skipping previous modals
 In some cases you might want to skip previous modals. For example:
 1. Team overview modal

--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -16,6 +16,10 @@ window.LivewireUIModal = () => {
                 return;
             }
 
+            if (!this.closingModal('closingModalOnEscape')) {
+                return;
+            }
+
             let force = this.getActiveComponentModalAttribute('closeOnEscapeIsForceful') === true;
             this.closeModal(force);
         },
@@ -24,7 +28,23 @@ window.LivewireUIModal = () => {
                 return;
             }
 
+            if (!this.closingModal('closingModalOnClickAway')) {
+                return;
+            }
+
             this.closeModal(true);
+        },
+        closingModal(eventName) {
+            const componentName = this.$wire.get('components')[this.activeComponent].name;
+
+            var params = {
+                id: this.activeComponent,
+                closing: true,
+            };
+
+            Livewire.dispatchTo(componentName, eventName, params);
+
+            return params.closing;
         },
         closeModal(force = false, skipPreviousModals = 0, destroySkipped = false) {
             if(this.show === false) {

--- a/resources/js/modal.js
+++ b/resources/js/modal.js
@@ -101,7 +101,7 @@ window.LivewireUIModal = () => {
             });
         },
         focusables() {
-            let selector = 'a, button, input:not([type=\'hidden\'], textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+            let selector = 'a, button, input:not([type=\'hidden\'], textarea, select, details, [tabindex]:not([tabindex=\'-1\']))'
 
             return [...this.$el.querySelectorAll(selector)]
                 .filter(el => !el.hasAttribute('disabled'))


### PR DESCRIPTION
This PR allows a modal to prevent closure on Escape or on click away based on its state. 

The idea is that before closing the modal, an event is dispatched, and the modal can handle it and, if needed, prevent closing the modal.

For example, if a modal has a `isDirty` property, it could have the following handler:

```
@script
<script>
    $wire.on('closingModalOnEscape', data => {
        if ($wire.isDirty && !confirm('{{ __('You have unsaved changes. Are you sure you want to close this dialog?') }}')) {
            data.closing = false;
        }
    });
    $wire.on('closingModalOnClickAway', data => {
        if ($wire.isDirty && !confirm('{{ __('You have unsaved changes. Are you sure you want to close this dialog?') }}')) {
            data.closing = false;
        }
    });
</script>
@endscript
```