### PR TITLE
Fix modal content visibility

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -40,7 +40,7 @@
                     x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                     x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-bind:class="modalWidth"
-                    class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
+                    class="relative inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
                     id="modal-container"
                     x-trap.noscroll.inert="show && showActiveComponent"
                     aria-modal="true"


### PR DESCRIPTION
My modal was behind the overlay when upgrading to Tailwind v4.

![Screenshot 2025-06-20 at 01 34 29](https://github.com/user-attachments/assets/36d948e6-9d5c-4217-b719-09cc851afb25)

Adding position relative fixed this for me. Not sure why tbh.

![Screenshot 2025-06-20 at 01 34 48](https://github.com/user-attachments/assets/c8a3277f-35a2-4475-8296-d366c217d7a8)
