### PR TITLE
Removed version from composer install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Click the image above to read a full article on using the Wire Elements modal pa
 To get started, require the package via Composer:
 
 ```
-composer require wire-elements/modal:^2.0
+composer require wire-elements/modal
 ```
 
 ## Livewire directive


### PR DESCRIPTION
Since the release of version 3 of this package, if you use the command from the readme the package will not install if you use Livewire v4